### PR TITLE
Adds ability to customize which promise library to use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,27 @@ This package is available on npm as:
 npm install dustjs-browserify
 ```
 
-## Browserify config example
+## Browserify `package.json` example
 
 ```
-transform: [
-  [
-    {
-      path    : 'lib/templates'
-      promise : true
-    },
-    'dustjs-browserify'
-  ]
-]
+{
+  ...
+  "browserify": {
+    "transform": [
+      [
+        {
+          "path"     : "lib/templates",
+          "promises" : "bluebird"
+        },
+        "dustjs-browserify"
+      ]
+    ]
+  },
+  ...
+  "devDependencies": {
+    "bluebird": "*"
+  }
+}
 ```
 
 ## Code examples
@@ -58,12 +67,14 @@ template({ foo : 42 }, function (error, html) {
 });
 ```
 
-Example using a promise:
+Example using a promise library such as `bluebird`:
 
 ```
 require('dustjs-loader').register({
-   path    : 'lib/templates',
-   promise : true
+   path : 'lib/templates',
+
+   // Promises library you with to use, please make sure it `npm install` it.
+   promises : 'bluebird'
 });
 
 var template = require('./template.dust');
@@ -75,6 +86,17 @@ template({ foo : 42 })
   .catch(function (error) {
     ...
   });
+```
+
+Example using ES6 promise:
+
+```
+require('dustjs-loader').register({
+   path : 'lib/templates',
+
+   // Will use promises but won't require any libraries expecting browser to provide.
+   promises : true
+});
 ```
 
 Both of these examples will work on the server and in the browser.

--- a/lib/dustjs-browserify.js
+++ b/lib/dustjs-browserify.js
@@ -76,7 +76,11 @@ module.exports = function (filename, options) {
     template = requires + template;
 
     if (options.promise) {
-      compiled = DustjsModulize.wrapWithPromise(name, template);
+      throw new Error('dustjs-browserify: `promise` option is deprecated. Please see README.');
+    }
+
+    if (options.promises) {
+      compiled = DustjsModulize.wrapWithPromise(name, template, options.promises);
     } else {
       compiled = DustjsModulize.wrap(name, template);
     }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "homepage": "https://github.com/scottbrady/dustjs-browserify",
   "dependencies": {
-    "bluebird": "~2.7.1",
     "dustjs-linkedin": "~2.5.1",
     "dustjs-loader": "~1.0.0",
     "through": "~2.3.6"


### PR DESCRIPTION
I'm working on an ES6 project. This could be useful also if you don't want the full weight of `bluebird`. Depends on https://github.com/scottbrady/dustjs-loader/pull/2

Please let me know if you want a hand maintaing this module (git and npm). I help out with a bunch of other modules (https://npmjs.org/~alexgorbatchev).
